### PR TITLE
Include tools so it is easier for others to compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .archive/*
-tools/*
 __pycache__/*


### PR DESCRIPTION
The tools folder hadn't been included since it contained a couple executables I made. Since they have credit under `--help`, go ahead and include them so it is easier for people to compile your site.