### PR TITLE
Fix newline issue with including tools

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+build eol=lf
+*.sh eol=lf


### PR DESCRIPTION
Linux and Windows use different ways of representing a newline:
eg:
```
Lorem<newline>
Ipsum
```
Since the build script runs on WSL, you need the line endings to be Linux compatible or the script will fail. Normally, GitHub will change your newlines to what it thinks is best for you, but we need to tell it to treat bash/shell `*.sh` files and the build file (which is a bash/shell script without the extension) as having Linux line endings.